### PR TITLE
Update shares cleanup (re: SHOW SHARES changes).

### DIFF
--- a/data-clean-room/consumer_init.sql
+++ b/data-clean-room/consumer_init.sql
@@ -50,7 +50,7 @@ create warehouse if not exists app_wh;
 show shares;
 execute immediate $$
 declare
-  res resultset default (select $3 as name from table(result_scan(last_query_id())) where $4 = 'DCR_SAMP_CONSUMER');
+  res resultset default (select $4 as name from table(result_scan(last_query_id())) where $5 = 'DCR_SAMP_CONSUMER');
   c1 cursor for res;
   share_var string;
 begin

--- a/data-clean-room/consumer_uninstall.sql
+++ b/data-clean-room/consumer_uninstall.sql
@@ -19,7 +19,7 @@ use role data_clean_room_role;
 show shares;
 execute immediate $$
 declare
-  res resultset default (select $3 as name from table(result_scan(last_query_id())) where $4 = 'DCR_SAMP_CONSUMER');
+  res resultset default (select $4 as name from table(result_scan(last_query_id())) where $5 = 'DCR_SAMP_CONSUMER');
   c1 cursor for res;
   share_var string;
 begin


### PR DESCRIPTION
This PR fixes the issue where, following a [change in the SHOW SHARES command](https://docs.snowflake.com/en/release-notes/bcr-bundles/2023_05/bcr-1180), the shares cleanup now fails with an error: `Database 'DCR_SAMP_CONSUMER' cannot be dropped. It is still shared by 1 shares, including shares 'DCR_SAMP_REQUESTS_XXXXXXX'`, where XXXXXXX is the Provider account locator.